### PR TITLE
Fix TS1192: missing default export

### DIFF
--- a/__test__/index.ts
+++ b/__test__/index.ts
@@ -1,6 +1,7 @@
 import vitePluginRequireTransform from "../src";
 import { readFileSync, writeFileSync } from "fs";
-import glob from "glob"
+
+const glob = require('glob')
 
 
 glob("__test__/case1/*.ts", {
@@ -37,7 +38,7 @@ glob("__test__/case3/*.ts", {
         ).transform(fileContent, file);
         writeFileSync(file.replace('.ts', '_transformed_result.ts'), transformedContent.code);
     }
-})  
+})
 
 glob("__test__/case4/*.ts", {
     ignore: "**/*transformed_result.ts"

--- a/package.json
+++ b/package.json
@@ -3,14 +3,18 @@
   "version": "1.0.8",
   "description": "A plugin for vite that convert from require syntax to import that compat for es module.",
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "package.json"
-  ],
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "test": "ts-node  __test__/index.ts",
-    "build": "rm -rf dist &&  tsc",
+    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "prepare": "npm run build",
     "ver": "npm version patch",
     "pub": "npm run prepare && npm run ver && npm publish"
@@ -41,6 +45,7 @@
     "@types/node": "^16.11.6",
     "glob": "^7.2.0",
     "ts-node": "^10.4.0",
+    "tsup": "^6.7.0",
     "typescript": "^4.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "scripts": {
     "test": "ts-node  __test__/index.ts",
     "build": "rm -rf dist &&  tsc",
+    "prepare": "npm run build",
     "ver": "npm version patch",
-    "pub": "npm run build && npm run ver && npm publish"
+    "pub": "npm run prepare && npm run ver && npm publish"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ type VitePluginRequireTransformParamsType = {
 	//to deal with the requireSpecifier
 	importPathHandler?: Function
 }
-module.exports = function vitePluginRequireTransform(
+
+export default function vitePluginRequireTransform(
 	params: VitePluginRequireTransformParamsType = {}
 ) {
 


### PR DESCRIPTION
Fixes #39 #40 #41 #42 

You can test this by doing `npm install github:trijpstra-fourlights/vite-plugin-require-transform#fix/typescript-types-missing`